### PR TITLE
Added logic for hardware interfaces

### DIFF
--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -304,6 +304,11 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
     resource_manager_->import_component(std::move(gazeboSystem), control_hardware[i]);
   }
 
+  rclcpp_lifecycle::State state(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+    hardware_interface::lifecycle_state_names::ACTIVE);
+  resource_manager_->set_component_state("GazeboSimSystem", state);
+
   impl_->executor_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
 
   // Create the controller manager


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

It might be related with this issues https://github.com/ros-controls/gz_ros2_control/issues/62

hardware interfaces now have state logic around them, so they need to be set in the active state. I tried the command added in the issue

```
ros2 service call controller_manager/set_hardware_component_state controller_manager_msgs/srv/SetHardwareComponentState '{name: 'GazeboSimSystem', target_state: {id: 3, label: ""}}'
```

and it works but these few lines have the same effect