### PR TITLE
Fixed CMake source file extension

### DIFF
--- a/gazebo_ros2_control_demos/CMakeLists.txt
+++ b/gazebo_ros2_control_demos/CMakeLists.txt
@@ -47,7 +47,7 @@ ament_target_dependencies(example_effort
   std_msgs
 )
 
-add_executable(example_gripper examples/example_gripper)
+add_executable(example_gripper examples/example_gripper.cpp)
 ament_target_dependencies(example_gripper
   rclcpp
   std_msgs


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

Fixed CMake source file extension to avoid a warning in the buildfarm