### PR TITLE
activated all hardware by default

### DIFF
--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -302,12 +302,12 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
     }
 
     resource_manager_->import_component(std::move(gazeboSystem), control_hardware[i]);
-  }
 
-  rclcpp_lifecycle::State state(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-    hardware_interface::lifecycle_state_names::ACTIVE);
-  resource_manager_->set_component_state("GazeboSystem", state);
+    rclcpp_lifecycle::State state(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+      hardware_interface::lifecycle_state_names::ACTIVE);
+    resource_manager_->set_component_state(control_hardware[i].name, state);
+  }
 
   impl_->executor_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
 


### PR DESCRIPTION
Default activation of hardware names `GazeboSystem` is very restrictive. Suggestion to set all hardware to `available` by default. 