### PR TITLE
[backport galactic] Adding simulation time parameter for the controller manager (#138)

### DIFF
--- a/gazebo_ros2_control_demos/config/diff_drive_controller.yaml
+++ b/gazebo_ros2_control_demos/config/diff_drive_controller.yaml
@@ -1,6 +1,7 @@
 controller_manager:
   ros__parameters:
     update_rate: 100  # Hz
+    use_sim_time: true
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster


### PR DESCRIPTION
Adding the simulation parameter so that the controller manager uses the simulation time instead of the ROS time.  The '/odom' and corresponding tf will only be published if this parameter is set to true.