### PR TITLE
 Force setting use_sim_time parameter when using plugin.

### DIFF
--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -348,7 +348,6 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
         " s) is slower than the gazebo simulation period (" <<
         gazebo_period.seconds() << " s).");
   }
-   
   // Force setting of use_sime_time parameter
   impl_->controller_manager_->set_parameter(
     rclcpp::Parameter("use_sim_time", rclcpp::ParameterValue(true)));

--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -348,6 +348,10 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
         " s) is slower than the gazebo simulation period (" <<
         gazebo_period.seconds() << " s).");
   }
+   
+  // Force setting of use_sime_time parameter
+  impl_->controller_manager_->set_parameter(
+    rclcpp::Parameter("use_sim_time", rclcpp::ParameterValue(true)));
 
   impl_->stop_ = false;
   auto spin = [this]()


### PR DESCRIPTION
The same change as done for Gazebo Sim in ros_controls/gz_ros2_control#100


Should resolve issues like #156 