### PR TITLE
[humble] Force setting use_sim_time parameter when using plugin.

### DIFF
--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -348,6 +348,9 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
         " s) is slower than the gazebo simulation period (" <<
         gazebo_period.seconds() << " s).");
   }
+  // Force setting of use_sime_time parameter
+  impl_->controller_manager_->set_parameter(
+    rclcpp::Parameter("use_sim_time", rclcpp::ParameterValue(true)));
 
   impl_->stop_ = false;
   auto spin = [this]()


### PR DESCRIPTION
Cherry-pick https://github.com/ros-controls/gazebo_ros2_control/commit/cc5746bad6820a39d158eec87c0100126f78a6ab from `master` branch to force `use_sim_time` to true in humble