### PR TITLE
Fixed rolling compilation

### DIFF
--- a/gazebo_ros2_control/CMakeLists.txt
+++ b/gazebo_ros2_control/CMakeLists.txt
@@ -39,6 +39,10 @@ ament_target_dependencies(${PROJECT_NAME}
   yaml_cpp_vendor
 )
 
+if("$ENV{ROS_DISTRO}" STREQUAL "rolling")
+  add_definitions(-DROLLING)
+endif()
+
 add_library(gazebo_hardware_plugins SHARED
   src/gazebo_system.cpp
 )

--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -287,7 +287,11 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
   }
 
   for (unsigned int i = 0; i < control_hardware_info.size(); i++) {
+#ifndef ROLLING
+    std::string robot_hw_sim_type_str_ = control_hardware_info[i].hardware_class_type;
+#else
     std::string robot_hw_sim_type_str_ = control_hardware_info[i].hardware_plugin_name;
+    #endif
     auto gazeboSystem = std::unique_ptr<gazebo_ros2_control::GazeboSystemInterface>(
       impl_->robot_hw_sim_loader_->createUnmanagedInstance(robot_hw_sim_type_str_));
 


### PR DESCRIPTION
Related with this issue in the buildfarm https://build.ros2.org/job/Hdev__gazebo_ros2_control__ubuntu_jammy_amd64/32/console

we use the same solution in `gz_ros2_control`