### PR TITLE
Fix deprecated copy warning

### DIFF
--- a/gazebo_ros2_control/include/gazebo_ros2_control/gazebo_system_interface.hpp
+++ b/gazebo_ros2_control/include/gazebo_ros2_control/gazebo_system_interface.hpp
@@ -44,6 +44,7 @@ public:
   : mFlags(original.mFlags) {}
   ~SafeEnum() = default;
 
+  SafeEnum & operator=(const SafeEnum & original) = default;
   SafeEnum & operator|=(ENUM addValue) {mFlags |= addValue; return *this;}
   SafeEnum operator|(ENUM addValue) {SafeEnum result(*this); result |= addValue; return result;}
   SafeEnum & operator&=(ENUM maskValue) {mFlags &= maskValue; return *this;}


### PR DESCRIPTION
Hi,

Here's a simple change to remove a compilation warning that is complaining about a copy assignment for the type `SafeEnum`.

It's also happening in humble so if you could create a backport it would be awesome :)