### PR TITLE
Update github_url link

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,4 +1,4 @@
-:github_url: https://github.com/ros-controls/gazebo_ros2_control/blob/{github_branch}/doc/index.rst
+:github_url: https://github.com/ros-controls/gazebo_ros2_control/blob/{REPOS_FILE_BRANCH}/doc/index.rst
 
 .. _gazebo_ros2_control:
 


### PR DESCRIPTION
The github url link on control.ros.org is not working after the merge of https://github.com/ros-controls/control.ros.org/pull/98 