### PR TITLE
Remove plugin export (ROS 1 syntax)

### DIFF
--- a/gazebo_ros2_control/package.xml
+++ b/gazebo_ros2_control/package.xml
@@ -34,6 +34,5 @@
 
   <export>
     <build_type>ament_cmake</build_type>
-    <gazebo_ros2_control plugin="${prefix}/gazebo_hardware_plugins.xml"/>
   </export>
 </package>


### PR DESCRIPTION
I think that the pluginlib macros in the export section are not necessary any more, `pluginlib_export_plugin_description_file` in CMakeLists does the job. See the official docs:

- https://docs.ros.org/en/humble/Tutorials/Beginner-Client-Libraries/Pluginlib.html#cmake-plugin-declaration
- https://github.com/ros/pluginlib/blob/6c441f70ed7fd3d75d61210b99f8e02954a6c9a3/pluginlib/cmake/pluginlib_export_plugin_description_file.cmake#L50-L65