### PR TITLE
Fix sagging robots in position control

### DIFF
--- a/gazebo_ros2_control/src/gazebo_system.cpp
+++ b/gazebo_ros2_control/src/gazebo_system.cpp
@@ -603,6 +603,7 @@ hardware_interface::return_type GazeboSystem::write(
     if (this->dataPtr->sim_joints_[j]) {
       if (this->dataPtr->joint_control_methods_[j] & POSITION) {
         this->dataPtr->sim_joints_[j]->SetPosition(0, this->dataPtr->joint_position_cmd_[j], true);
+        this->dataPtr->sim_joints_[j]->SetVelocity(0, 0.0);
       } else if (this->dataPtr->joint_control_methods_[j] & VELOCITY) { // NOLINT
         this->dataPtr->sim_joints_[j]->SetVelocity(0, this->dataPtr->joint_velocity_cmd_[j]);
       } else if (this->dataPtr->joint_control_methods_[j] & EFFORT) { // NOLINT


### PR DESCRIPTION
Following up with my remarks on https://github.com/ros-controls/gazebo_ros2_control/pull/177#issuecomment-1584743086 and a request for a PR.

summary: in the discussion of the [reset pos/vel commands](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-gazebo/pull-requests/437/page/1) it is said that setting position/velocity for joints is overriding physics, and should generally not be used,

I know from past experience with enforcing pose of an object at each time step was not sufficient to hold it in place (drift), velocity had to be set to zero as well. I immediately related the joint sagging issue to that pose drift.

Solution is to set zero velocity as well for that time step. Setting velocity to zero after fixing position is another override that stabilizes the physics and is unrelated to any robot physics.


here is a before and after on 2 robots

https://github.com/ros-controls/gazebo_ros2_control/assets/132376938/779a6c28-7479-471b-b1ef-ea1d9ea85150


https://github.com/ros-controls/gazebo_ros2_control/assets/132376938/97b2fc07-10a4-4985-9829-8ff768ec410e

https://github.com/ros-controls/gazebo_ros2_control/assets/132376938/14e6e9ea-f0f9-491e-88ca-f2530c94ab39


https://github.com/ros-controls/gazebo_ros2_control/assets/132376938/b0389edc-a6ba-43f9-b2d5-8aeeaf428567





Other solutions have used max efforts or adding high damping (which probably essentially set velocity to zero)

I believe this PR should therefore fix the following issues without requiring dynamics parameters. 

https://github.com/ros-controls/gazebo_ros2_control/issues/90
https://github.com/ros-controls/gazebo_ros2_control/issues/73
https://github.com/UniversalRobots/Universal_Robots_ROS2_Gazebo_Simulation/issues/19