### PR TITLE
Remove Moveit2 example

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -278,20 +278,3 @@ Send example commands:
 .. code-block:: shell
 
   ros2 run gazebo_ros2_control_demos example_gripper
-
-
-Gazebo Classic + Moveit2 + ROS 2
-==========================================
-
-This example works with `ROS 2 Foxy <https://index.ros.org/doc/ros2/Installation/Foxy/>`__.
-You should install Moveit2 from sources, the instructions are available in this `link <https://moveit.ros.org/install-moveit2/source/>`__.
-
-The repository with all the required packages are in the `gazebo_ros_demos <https://github.com/ros-controls/gazebo_ros_demos/tree/ahcorde/port/ros2>`__.
-
-.. code-block:: shell
-
-  ros2 launch rrbot_moveit_demo_nodes rrbot_demo.launch.py
-
-
-.. image:: img/moveit2.gif
-  :alt: moveit2


### PR DESCRIPTION
The example is not working any more, fixing #217.

Please also backport to humble.