### PR TITLE
Activate CI for humble

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: Gazebo ros2 control CI
 on:
   pull_request:
   push:
-    branches: 
+    branches:
       - master
       - humble
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,9 @@ name: Gazebo ros2 control CI
 on:
   pull_request:
   push:
-    branches: [ master ]
+    branches: 
+      - master
+      - humble
 
 jobs:
   build:


### PR DESCRIPTION
CI is not activated for branches other than master:

[![Gazebo ros2 control CI](https://github.com/ros-controls/gazebo_ros2_control/actions/workflows/ci.yaml/badge.svg?branch=humble)](https://github.com/ros-controls/gazebo_ros2_control/actions/workflows/ci.yaml)

I don't think this is on purpose?