### PR TITLE
Update diff_drive_controller.yaml

### DIFF
--- a/gazebo_ros2_control_demos/config/diff_drive_controller.yaml
+++ b/gazebo_ros2_control_demos/config/diff_drive_controller.yaml
@@ -24,7 +24,7 @@ diff_drive_base_controller:
 
     publish_rate: 50.0
     odom_frame_id: odom
-    base_frame_id: base_link
+    base_frame_id: chassis
     pose_covariance_diagonal : [0.001, 0.001, 0.0, 0.0, 0.0, 0.01]
     twist_covariance_diagonal: [0.001, 0.0, 0.0, 0.0, 0.0, 0.01]
 


### PR DESCRIPTION
The wrong base frame is set. The name of the link in the URDF is chassis.