### PR TITLE
Catch pluginlib exceptions

### DIFF
--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -289,7 +289,7 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
   for (unsigned int i = 0; i < control_hardware_info.size(); i++) {
     std::string robot_hw_sim_type_str_ = control_hardware_info[i].hardware_plugin_name;
     RCLCPP_DEBUG(
-      impl_->model_nh_->get_logger(), "Load hw interface %s ...",
+      impl_->model_nh_->get_logger(), "Load hardware interface %s ...",
       robot_hw_sim_type_str_.c_str());
     std::unique_ptr<gazebo_ros2_control::GazeboSystemInterface> gazeboSystem;
     try {
@@ -304,7 +304,7 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
     rclcpp::Node::SharedPtr node_ros2 = std::dynamic_pointer_cast<rclcpp::Node>(
       impl_->model_nh_);
     RCLCPP_DEBUG(
-      impl_->model_nh_->get_logger(), "Loaded hw interface %s!",
+      impl_->model_nh_->get_logger(), "Loaded hardware interface %s!",
       robot_hw_sim_type_str_.c_str());
     if (!gazeboSystem->initSim(
         node_ros2,

--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -288,10 +288,24 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
 
   for (unsigned int i = 0; i < control_hardware_info.size(); i++) {
     std::string robot_hw_sim_type_str_ = control_hardware_info[i].hardware_plugin_name;
-    auto gazeboSystem = std::unique_ptr<gazebo_ros2_control::GazeboSystemInterface>(
-      impl_->robot_hw_sim_loader_->createUnmanagedInstance(robot_hw_sim_type_str_));
-
-    rclcpp::Node::SharedPtr node_ros2 = std::dynamic_pointer_cast<rclcpp::Node>(impl_->model_nh_);
+    RCLCPP_DEBUG(
+      impl_->model_nh_->get_logger(), "Load hw interface %s ...",
+      robot_hw_sim_type_str_.c_str());
+    std::unique_ptr<gazebo_ros2_control::GazeboSystemInterface> gazeboSystem;
+    try {
+      gazeboSystem = std::unique_ptr<gazebo_ros2_control::GazeboSystemInterface>(
+        impl_->robot_hw_sim_loader_->createUnmanagedInstance(robot_hw_sim_type_str_));
+    } catch (pluginlib::PluginlibException & ex) {
+      RCLCPP_ERROR(
+        impl_->model_nh_->get_logger(), "The plugin failed to load for some reason. Error: %s\n",
+        ex.what());
+      continue;
+    }
+    rclcpp::Node::SharedPtr node_ros2 = std::dynamic_pointer_cast<rclcpp::Node>(
+      impl_->model_nh_);
+    RCLCPP_DEBUG(
+      impl_->model_nh_->get_logger(), "Loaded hw interface %s!",
+      robot_hw_sim_type_str_.c_str());
     if (!gazeboSystem->initSim(
         node_ros2,
         impl_->parent_model_,
@@ -302,6 +316,9 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
         impl_->model_nh_->get_logger(), "Could not initialize robot simulation interface");
       return;
     }
+    RCLCPP_DEBUG(
+      impl_->model_nh_->get_logger(), "Initialized robot simulation interface %s!",
+      robot_hw_sim_type_str_.c_str());
 
     resource_manager_->import_component(std::move(gazeboSystem), control_hardware_info[i]);
 


### PR DESCRIPTION
I recently worked with custom simulation plugins as described [in the docs](https://control.ros.org/master/doc/gazebo_ros2_control/doc/index.html#advanced-custom-gazebo-ros2-control-simulation-plugins).

It took me a while to debug the ClassLoader, I propose a catch on pluginlib exceptions.

As an example, a non-existing plugin name in the urdf
```xml
      <hardware>
        <plugin>gazebo_ros2_control_actuators/GazeboSystemWrong</plugin>
      </hardware>
```
was just not loaded and gzserver died. Now it is catched with the following error message
```
[gzserver-1] [ERROR] [1692356394.343300163] [gazebo_ros2_control]: The plugin failed to load for some reason. Error: According to the loaded plugin descriptions the class gazebo_ros2_control/GazeboSystemWrong with base class type gazebo_ros2_control::GazeboSystemInterface does not exist. Declared types are ...
```