### PR TITLE
Cleanup controller config

### DIFF
--- a/gazebo_ros2_control_demos/config/cartpole_controller_effort.yaml
+++ b/gazebo_ros2_control_demos/config/cartpole_controller_effort.yaml
@@ -12,9 +12,3 @@ effort_controllers:
   ros__parameters:
     joints:
       - slider_to_cart
-    command_interfaces:
-      - effort
-    state_interfaces:
-      - position
-      - velocity
-      - effort

--- a/gazebo_ros2_control_demos/config/cartpole_controller_effort.yaml
+++ b/gazebo_ros2_control_demos/config/cartpole_controller_effort.yaml
@@ -2,13 +2,13 @@ controller_manager:
   ros__parameters:
     update_rate: 100  # Hz
 
-    effort_controllers:
+    effort_controller:
       type: effort_controllers/JointGroupEffortController
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
-effort_controllers:
+effort_controller:
   ros__parameters:
     joints:
       - slider_to_cart

--- a/gazebo_ros2_control_demos/config/cartpole_controller_velocity.yaml
+++ b/gazebo_ros2_control_demos/config/cartpole_controller_velocity.yaml
@@ -15,11 +15,7 @@ velocity_controller:
   ros__parameters:
     joints:
       - slider_to_cart
-    command_interfaces:
-      - velocity
-    state_interfaces:
-      - position
-      - velocity
+
 imu_sensor_broadcaster:
   ros__parameters:
     sensor_name: cart_imu_sensor

--- a/gazebo_ros2_control_demos/examples/example_effort.cpp
+++ b/gazebo_ros2_control_demos/examples/example_effort.cpp
@@ -29,7 +29,7 @@ int main(int argc, char * argv[])
   node = std::make_shared<rclcpp::Node>("effort_test_node");
 
   auto publisher = node->create_publisher<std_msgs::msg::Float64MultiArray>(
-    "/effort_controllers/commands", 10);
+    "/effort_controller/commands", 10);
 
   RCLCPP_INFO(node->get_logger(), "node created");
 

--- a/gazebo_ros2_control_demos/launch/cart_example_effort.launch.py
+++ b/gazebo_ros2_control_demos/launch/cart_example_effort.launch.py
@@ -63,7 +63,7 @@ def generate_launch_description():
     )
 
     load_joint_trajectory_controller = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active', 'effort_controllers'],
+        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active', 'effort_controller'],
         output='screen'
     )
 


### PR DESCRIPTION
The controller config of the velocity and effort controllers (specializations of the forward_command_controller) had some non-existing parameters in the yaml.

See the config files in the [demo repository](https://github.com/ros-controls/ros2_control_demos/blob/master/example_3/bringup/config/rrbot_multi_interface_forward_controllers.yaml) or the [PR to update the docs](https://github.com/ros-controls/ros2_controllers/pull/765).