### PR TITLE
Replace double quotes with single ones

### DIFF
--- a/gazebo_ros2_control_demos/launch/tricycle_drive.launch.py
+++ b/gazebo_ros2_control_demos/launch/tricycle_drive.launch.py
@@ -69,13 +69,13 @@ def generate_launch_description():
     )
 
     rviz = Node(
-        package="rviz2",
-        executable="rviz2",
+        package='rviz2',
+        executable='rviz2',
         arguments=[
-            "-d",
-            os.path.join(gazebo_ros2_control_demos_path, "config/config.rviz"),
+            '-d',
+            os.path.join(gazebo_ros2_control_demos_path, 'config/config.rviz'),
         ],
-        output="screen",
+        output='screen',
     )
 
     return LaunchDescription([


### PR DESCRIPTION
flake8 is complaining about double quotes. I'm not sure why [this CI job fails](https://github.com/ros-controls/control.ros.org/actions/runs/6917705161/job/18819180709#step:6:24195) and others don't, but this is a simple fix.