### PR TITLE
Add `hold_joints` parameter

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -155,6 +155,7 @@ The *gazebo_ros2_control* ``<plugin>`` tag also has the following optional child
 * ``<robot_param>``: The location of the ``robot_description`` (URDF) on the parameter server, defaults to ``robot_description``
 * ``<robot_param_node>``: Name of the node where the ``robot_param`` is located, defaults to ``robot_state_publisher``
 * ``<parameters>``: YAML file with the configuration of the controllers
+* ``<hold_joints>``: if set to true (default), it will hold the joints' position if the interface was not claimed, e.g., the controller hasn't been activated yet.
 
 Default gazebo_ros2_control Behavior
 -----------------------------------------------------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -155,7 +155,7 @@ The *gazebo_ros2_control* ``<plugin>`` tag also has the following optional child
 * ``<robot_param>``: The location of the ``robot_description`` (URDF) on the parameter server, defaults to ``robot_description``
 * ``<robot_param_node>``: Name of the node where the ``robot_param`` is located, defaults to ``robot_state_publisher``
 * ``<parameters>``: YAML file with the configuration of the controllers
-* ``<hold_joints>``: if set to true (default), it will hold the joints' position if the interface was not claimed, e.g., the controller hasn't been activated yet.
+* ``<hold_joints>``: if set to true (default), it will hold the joints' position if their interface was not claimed, e.g., the controller hasn't been activated yet.
 
 Default gazebo_ros2_control Behavior
 -----------------------------------------------------------

--- a/gazebo_ros2_control/include/gazebo_ros2_control/gazebo_system.hpp
+++ b/gazebo_ros2_control/include/gazebo_ros2_control/gazebo_system.hpp
@@ -88,6 +88,9 @@ private:
 
   /// \brief Private data class
   std::unique_ptr<GazeboSystemPrivate> dataPtr;
+
+  // Should hold the joints if no control_mode is active
+  bool hold_joints_ = true;
 };
 
 }  // namespace gazebo_ros2_control

--- a/gazebo_ros2_control/include/gazebo_ros2_control/gazebo_system.hpp
+++ b/gazebo_ros2_control/include/gazebo_ros2_control/gazebo_system.hpp
@@ -88,9 +88,6 @@ private:
 
   /// \brief Private data class
   std::unique_ptr<GazeboSystemPrivate> dataPtr;
-
-  // Should hold the joints if no control_mode is active
-  bool hold_joints_ = true;
 };
 
 }  // namespace gazebo_ros2_control

--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -314,8 +314,20 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
       robot_hw_sim_type_str_.c_str());
     try {
       node_ros2->declare_parameter("hold_joints", rclcpp::ParameterValue(hold_joints));
-    } catch (const std::exception & e) {
-      RCLCPP_ERROR(impl_->model_nh_->get_logger(), "%s", e.what());
+    } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException & e) {
+      RCLCPP_ERROR(
+        impl_->model_nh_->get_logger(), "Parameter 'hold_joints' has already been declared, %s",
+        e.what());
+    } catch (const rclcpp::exceptions::InvalidParametersException & e) {
+      RCLCPP_ERROR(
+        impl_->model_nh_->get_logger(), "Parameter 'hold_joints' has invalid name, %s", e.what());
+    } catch (const rclcpp::exceptions::InvalidParameterValueException & e) {
+      RCLCPP_ERROR(
+        impl_->model_nh_->get_logger(), "Parameter 'hold_joints' value is invalid, %s", e.what());
+    } catch (const rclcpp::exceptions::InvalidParameterTypeException & e) {
+      RCLCPP_ERROR(
+        impl_->model_nh_->get_logger(), "Parameter 'hold_joints' value has wrong type, %s",
+        e.what());
     }
     if (!gazeboSystem->initSim(
         node_ros2,

--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -182,6 +182,12 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
   } else {
     impl_->robot_description_node_ = "robot_state_publisher";  // default
   }
+  // Hold joints if no control mode is active?
+  bool hold_joints = true;  // default
+  if (sdf->HasElement("hold_joints")) {
+    hold_joints =
+      sdf->GetElement("hold_joints")->Get<bool>();
+  }
 
   // There's currently no direct way to set parameters to the plugin's node
   // So we have to parse the plugin file manually and set it to the node's context.
@@ -306,6 +312,11 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
     RCLCPP_DEBUG(
       impl_->model_nh_->get_logger(), "Loaded hardware interface %s!",
       robot_hw_sim_type_str_.c_str());
+    try {
+      node_ros2->declare_parameter("hold_joints", rclcpp::ParameterValue(hold_joints));
+    } catch (const std::exception & e) {
+      RCLCPP_ERROR(impl_->model_nh_->get_logger(), "%s", e.what());
+    }
     if (!gazeboSystem->initSim(
         node_ros2,
         impl_->parent_model_,

--- a/gazebo_ros2_control/src/gazebo_system.cpp
+++ b/gazebo_ros2_control/src/gazebo_system.cpp
@@ -133,10 +133,22 @@ bool GazeboSystem::initSim(
 
   try {
     this->dataPtr->hold_joints_ = this->nh_->get_parameter("hold_joints").as_bool();
-  } catch (const std::exception & e) {
-    RCLCPP_WARN(
+  } catch (rclcpp::exceptions::ParameterUninitializedException & ex) {
+    RCLCPP_ERROR(
       this->nh_->get_logger(),
-      "Parameter 'hold_joints' not found, with error %s", e.what());
+      "Parameter 'hold_joints' not initialized, with error %s", ex.what());
+    RCLCPP_WARN_STREAM(
+      this->nh_->get_logger(), "Using default value: " << this->dataPtr->hold_joints_);
+  } catch (rclcpp::exceptions::ParameterNotDeclaredException & ex) {
+    RCLCPP_ERROR(
+      this->nh_->get_logger(),
+      "Parameter 'hold_joints' not declared, with error %s", ex.what());
+    RCLCPP_WARN_STREAM(
+      this->nh_->get_logger(), "Using default value: " << this->dataPtr->hold_joints_);
+  } catch (rclcpp::ParameterTypeException & ex) {
+    RCLCPP_ERROR(
+      this->nh_->get_logger(),
+      "Parameter 'hold_joints' has wrong type: %s", ex.what());
     RCLCPP_WARN_STREAM(
       this->nh_->get_logger(), "Using default value: " << this->dataPtr->hold_joints_);
   }

--- a/gazebo_ros2_control/src/gazebo_system.cpp
+++ b/gazebo_ros2_control/src/gazebo_system.cpp
@@ -128,6 +128,18 @@ bool GazeboSystem::initSim(
     return false;
   }
 
+  try {
+    hold_joints_ = this->nh_->get_parameter("hold_joints").as_bool();
+  } catch (const std::exception & e) {
+    RCLCPP_WARN(
+      this->nh_->get_logger(),
+      "Parameter 'hold_joints' not found, with error %s", e.what());
+    RCLCPP_WARN_STREAM(
+      this->nh_->get_logger(), "Using default value: " << hold_joints_);
+  }
+  RCLCPP_DEBUG_STREAM(
+    this->nh_->get_logger(), "hold_joints (system): " << hold_joints_ << std::endl);
+
   registerJoints(hardware_info, parent_model);
   registerSensors(hardware_info, parent_model);
 
@@ -601,7 +613,7 @@ hardware_interface::return_type GazeboSystem::write(
         this->dataPtr->sim_joints_[j]->SetVelocity(0, this->dataPtr->joint_velocity_cmd_[j]);
       } else if (this->dataPtr->joint_control_methods_[j] & EFFORT) { // NOLINT
         this->dataPtr->sim_joints_[j]->SetForce(0, this->dataPtr->joint_effort_cmd_[j]);
-      } else if (this->dataPtr->is_joint_actuated_[j]) {
+      } else if (this->dataPtr->is_joint_actuated_[j] && hold_joints_) {
         // Fallback case is a velocity command of zero (only for actuated joints)
         this->dataPtr->sim_joints_[j]->SetVelocity(0, 0.0);
       }


### PR DESCRIPTION
@HPCLOL posted a use case of gazebo in https://github.com/ros-controls/ros2_controllers/issues/875:
If the simulation is started with an inactive controller, the robot should move with gravity as if the joints were passive.

As discussed with #250 this is currently not possible. This PR adds an parameter to enable this behavior (again). 

- I'm not sure if this should be default true or false.
- I haven't found a different solution to tell `GazeboSystem` this parameter parsed from the gazebo plugin without changing API. Therefore, I used a ROS parameter of the gazebo_ros2_control node to pass the information.

The result looks like this if no controller was spawned:

https://github.com/ros-controls/gazebo_ros2_control/assets/3367244/45e2f56a-7173-4cee-a30e-02713127c63b


