### PR TITLE
Rolling CI add sign from ROS2 packages

### DIFF
--- a/.github/workflows/ci-rolling.yaml
+++ b/.github/workflows/ci-rolling.yaml
@@ -56,7 +56,8 @@ jobs:
         cd ..
         mkdir -p /home/ros2_ws/src
         cp -r gazebo_ros2_control /home/ros2_ws/src/
-        sh -c 'echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2-testing/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'
+        curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+        sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2-testing/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'
         apt-get update && apt-get upgrade -q -y
         apt-get update && apt-get install -q -y --no-install-recommends \
           dirmngr \


### PR DESCRIPTION
I saw these [error messages](https://github.com/ros-controls/gazebo_ros2_control/actions/runs/7476086437/job/20345684887?pr=255) when building rolling
```bash
W: GPG error: http://packages.ros.org/ros2-testing/ubuntu jammy InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY F42ED6FBAB17C654
E: The repository 'http://packages.ros.org/ros2-testing/ubuntu jammy InRelease' is not signed.
```