### PR TITLE
Load the URDF to the resource_manager before parsing it to CM 

### DIFF
--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -289,6 +289,13 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
     std::make_unique<hardware_interface::ResourceManager>();
 
   try {
+    resource_manager_->load_urdf(urdf_string, false);
+  } catch (...) {
+    // This error should be normal as the resource manager is not supposed to load and initialize
+    // them
+    RCLCPP_ERROR(impl_->model_nh_->get_logger(), "Error initializing URDF to resource manager!");
+  }
+  try {
     impl_->robot_hw_sim_loader_.reset(
       new pluginlib::ClassLoader<gazebo_ros2_control::GazeboSystemInterface>(
         "gazebo_ros2_control",

--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -289,7 +289,7 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
     std::make_unique<hardware_interface::ResourceManager>();
 
   try {
-    resource_manager_->load_urdf(urdf_string, false);
+    resource_manager_->load_urdf(urdf_string, false, false);
   } catch (...) {
     // This error should be normal as the resource manager is not supposed to load and initialize
     // them


### PR DESCRIPTION
These changes are needed after the merging of https://github.com/ros-controls/ros2_control/pull/1271 and https://github.com/ros-controls/ros2_control/pull/1272. It seems like the gazebo_ros2_control doesn't load the URDF into the resource manager, and this is causing the CM services not to start.

However, loading the URDF with the [`load_urdf`](https://github.com/ros-controls/ros2_control/blob/3309c6dbaf4ab5140d13908bedb6fb471c422498/hardware_interface/src/resource_manager.cpp#L759-L796) method will probably fail, because this method originally loads and initializes the hardware interfaces and this step might probably fail. For this reason, I'm catching the exception here, but the overall behaviour will work.

If approved, this will need backport to Iron and Humble

Needs: https://github.com/ros-controls/ros2_control/pull/1301
Fixes: https://github.com/ros-controls/ros2_control/issues/1299