### PR TITLE
Fix links in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # gazebo_ros2_control
 
-This is a ROS 2 package for integrating the `ros2_control` controller architecture with the [Gazebo Classic](http://gazebosim.org/) simulator.
+This is a ROS 2 package for integrating the `ros2_control` controller architecture with the [Gazebo Classic](https://classic.gazebosim.org/) simulator.
 
 This package provides a Gazebo plugin which instantiates a `ros2_control` controller manager and connects it to a Gazebo model.
 
 ## Documentation
-See the [documentation file](doc/index.rst) or [control.ros.org](https://control.ros.org/master/doc/simulators/gazebo_ros2_control/doc/index.html)
+See the [documentation file](doc/index.rst) or [control.ros.org](https://control.ros.org/master/doc/gazebo_ros2_control/doc/index.html).
 
 ## Build status
 

--- a/gazebo_ros2_control/README.md
+++ b/gazebo_ros2_control/README.md
@@ -1,7 +1,7 @@
 # Gazebo ros_control Interfaces
 
 This is a ROS 2 package for integrating the [ros2_control](https://github.com/ros-controls/ros2_control) controller architecture
-with the [Gazebo](http://gazebosim.org/) simulator.
+with the [Gazebo Classic](https://classic.gazebosim.org/) simulator.
 
 This package provides a Gazebo plugin which instantiates a ros_control
 controller manager and connects it to a Gazebo model.


### PR DESCRIPTION
* Fix links for Gazebo Classic to point to https://classic.gazebosim.org/ instead of https://gazebosim.org/ that is related to modern Gazebo libraries.
* Fix link to the documentation to point to https://control.ros.org/master/doc/gazebo_ros2_control/doc/index.html instead of non-working (at least for me) https://control.ros.org/master/doc/simulators/gazebo_ros2_control/doc/index.html URL



fyi @AleTarsi