### PR TITLE
set the robot description parameter

### DIFF
--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -185,10 +185,9 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
 
   // Read urdf from ros parameter server
   std::string urdf_string;
-  urdf_string = impl_->getURDF(impl_->robot_description_);  
-  if (urdf_string.empty())
-  {
-    RCLCPP_ERROR_STREAM(impl_->model_nh_->get_logger(), "An empty URDF was passed. Exiting.");    
+  urdf_string = impl_->getURDF(impl_->robot_description_);
+  if (urdf_string.empty()) {
+    RCLCPP_ERROR_STREAM(impl_->model_nh_->get_logger(), "An empty URDF was passed. Exiting.");
     return;
   }
 

--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -183,6 +183,15 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
     impl_->robot_description_node_ = "robot_state_publisher";  // default
   }
 
+  // Read urdf from ros parameter server
+  std::string urdf_string;
+  urdf_string = impl_->getURDF(impl_->robot_description_);  
+  if (urdf_string.empty())
+  {
+    RCLCPP_ERROR_STREAM(impl_->model_nh_->get_logger(), "An empty URDF was passed. Exiting.");    
+    return;
+  }
+
   // There's currently no direct way to set parameters to the plugin's node
   // So we have to parse the plugin file manually and set it to the node's context.
   auto rcl_context = impl_->model_nh_->get_node_base_interface()->get_context()->get_rcl_context();
@@ -201,6 +210,12 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
     RCLCPP_ERROR(
       impl_->model_nh_->get_logger(), "No parameter file provided. Configuration might be wrong");
   }
+
+  // set the robot description parameter
+  // to propagate it among controller manager and controllers
+  std::string rb_arg = std::string("robot_description:=") + urdf_string;
+  arguments.push_back(RCL_PARAM_FLAG);
+  arguments.push_back(rb_arg);
 
   if (sdf->HasElement("ros")) {
     sdf = sdf->GetElement("ros");
@@ -257,13 +272,10 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
       std::chrono::duration<double>(
         impl_->parent_model_->GetWorld()->Physics()->GetMaxStepSize())));
 
-  // Read urdf from ros parameter server then
   // setup actuators and mechanism control node.
   // This call will block if ROS is not properly initialized.
-  std::string urdf_string;
   std::vector<hardware_interface::HardwareInfo> control_hardware_info;
   try {
-    urdf_string = impl_->getURDF(impl_->robot_description_);
     control_hardware_info = hardware_interface::parse_control_resources_from_urdf(urdf_string);
   } catch (const std::runtime_error & ex) {
     RCLCPP_ERROR_STREAM(
@@ -434,7 +446,7 @@ std::string GazeboRosControlPrivate::getURDF(std::string param_name) const
       RCLCPP_ERROR(
         model_nh_->get_logger(), "Interrupted while waiting for %s service. Exiting.",
         robot_description_node_.c_str());
-      return 0;
+      return "";
     }
     RCLCPP_ERROR(
       model_nh_->get_logger(), "%s service not available, waiting again...",


### PR DESCRIPTION
This merge resolves the issue with robot description parameter in controller manager and controllers.
Some custom controllers require information about robot description, which are available normally over a parameter of controller manager and controllers in the ros2 control. However, this parameter was missing, if the controller manager (as well controllers) is started over gazebo ros2 control. Therefore, the custom controllers could not be used/tested with the gazebo.
I tested this code with my custom controllers. 

If you have some remarks, I would be glad to introduce some improvement.

Here is an output of parameter list before (without robot description parameter):

```
/controller_manager:
  forward_position_controller.type
  joint_state_broadcaster.type
  qos_overrides./clock.subscription.depth
  qos_overrides./clock.subscription.durability
  qos_overrides./clock.subscription.history
  qos_overrides./clock.subscription.reliability
  qos_overrides./parameter_events.publisher.depth
  qos_overrides./parameter_events.publisher.durability
  qos_overrides./parameter_events.publisher.history
  qos_overrides./parameter_events.publisher.reliability
  update_rate
  use_sim_time

/forward_position_controller:
  interface_name
  joints
  qos_overrides./clock.subscription.depth
  qos_overrides./clock.subscription.durability
  qos_overrides./clock.subscription.history
  qos_overrides./clock.subscription.reliability
  update_rate
  use_sim_time

/joint_state_broadcaster:
  extra_joints
  interfaces
  joints
  map_interface_to_joint_state.effort
  map_interface_to_joint_state.position
  map_interface_to_joint_state.velocity
  qos_overrides./clock.subscription.depth
  qos_overrides./clock.subscription.durability
  qos_overrides./clock.subscription.history
  qos_overrides./clock.subscription.reliability
  update_rate
  use_local_topics
  use_sim_time
```

And here is the output with the fix:
```
/controller_manager:
  forward_position_controller.type
  joint_state_broadcaster.type
  qos_overrides./clock.subscription.depth
  qos_overrides./clock.subscription.durability
  qos_overrides./clock.subscription.history
  qos_overrides./clock.subscription.reliability
  qos_overrides./parameter_events.publisher.depth
  qos_overrides./parameter_events.publisher.durability
  qos_overrides./parameter_events.publisher.history
  qos_overrides./parameter_events.publisher.reliability
  robot_description
  update_rate
  use_sim_time

/forward_position_controller:
  interface_name
  joints
  qos_overrides./clock.subscription.depth
  qos_overrides./clock.subscription.durability
  qos_overrides./clock.subscription.history
  qos_overrides./clock.subscription.reliability
  robot_description
  update_rate
  use_sim_time

/joint_state_broadcaster:
  extra_joints
  interfaces
  joints
  map_interface_to_joint_state.effort
  map_interface_to_joint_state.position
  map_interface_to_joint_state.velocity
  qos_overrides./clock.subscription.depth
  qos_overrides./clock.subscription.durability
  qos_overrides./clock.subscription.history
  qos_overrides./clock.subscription.reliability
  robot_description
  update_rate
  use_local_topics
  use_sim_time
```

To get the robot description parameter value over cli returns the correct urdf.