### PR TITLE
Cleanup of demos

### DIFF
--- a/gazebo_ros2_control_demos/config/cart_controller.yaml
+++ b/gazebo_ros2_control_demos/config/cart_controller.yaml
@@ -12,7 +12,6 @@ joint_trajectory_controller:
   ros__parameters:
     joints:
       - slider_to_cart
-    interface_name: position
     command_interfaces:
       - position
     state_interfaces:

--- a/gazebo_ros2_control_demos/package.xml
+++ b/gazebo_ros2_control_demos/package.xml
@@ -38,7 +38,6 @@
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>ros2_control</exec_depend>
-  <exec_depend>ros2_controllers</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>velocity_controllers</exec_depend>


### PR DESCRIPTION
Two minimal changes to the demos:

- no need for `interface_name: position`
- no dependency on ros2_controllers (all controllers are listed explicitly)
