### PR TITLE
Change initial pose of pendulum example

### DIFF
--- a/gazebo_ros2_control_demos/urdf/test_pendulum_effort.xacro.urdf
+++ b/gazebo_ros2_control_demos/urdf/test_pendulum_effort.xacro.urdf
@@ -68,7 +68,7 @@
 
   <joint name="cart_to_pendulum" type="revolute">
     <axis xyz="0 1 0"/>
-    <origin xyz="0.0 0.35 0.0" rpy="0 0.1 0"/>
+    <origin xyz="0.0 0.35 0.0" rpy="0 ${pi} 0"/>
     <parent link="cart"/>
     <child link="pendulum"/>
     <limit effort="10000.0" lower="-100000" upper="100000" velocity="100000"/>

--- a/gazebo_ros2_control_demos/urdf/test_pendulum_position.xacro.urdf
+++ b/gazebo_ros2_control_demos/urdf/test_pendulum_position.xacro.urdf
@@ -68,7 +68,7 @@
 
   <joint name="cart_to_pendulum" type="revolute">
     <axis xyz="0 1 0"/>
-    <origin xyz="0.0 0.35 0.0" rpy="0 0.1 0"/>
+    <origin xyz="0.0 0.35 0.0" rpy="0 ${pi} 0"/>
     <parent link="cart"/>
     <child link="pendulum"/>
     <limit effort="10000.0" lower="-100000" upper="100000" velocity="100000"/>


### PR DESCRIPTION
              > Now it's moving:

Passive joints were always "moving", but as if they were fixed in inertial frame. A movement of the parent link did not effect the respective joint.

For demonstration purposes, I change the initial pose to be in the lower equilibrium to make this clearer:
https://github.com/ros-controls/gazebo_ros2_control/assets/3367244/630cc8b8-6cb4-4dbc-9caa-948c085052e0

_Originally posted by @christophfroehlich in https://github.com/ros-controls/gazebo_ros2_control/issues/172#issuecomment-2105185043_
            