### PR TITLE
Initialize antiwindup variable properly

### DIFF
--- a/gazebo_ros2_control/src/gazebo_system.cpp
+++ b/gazebo_ros2_control/src/gazebo_system.cpp
@@ -179,7 +179,7 @@ control_toolbox::Pid GazeboSystem::extractPID(
   double kd;
   double max_integral_error;
   double min_integral_error;
-  bool antiwindup;
+  bool antiwindup = false;
 
   if (joint_info.parameters.find(prefix + "kp") != joint_info.parameters.end()) {
     kp = std::stod(joint_info.parameters.at(prefix + "kp"));
@@ -217,8 +217,6 @@ control_toolbox::Pid GazeboSystem::extractPID(
     {
       antiwindup = true;
     }
-  } else {
-    antiwindup = false;
   }
 
   RCLCPP_INFO_STREAM(


### PR DESCRIPTION
```
/workspaces/ros2_baustelle_ws/src/ros-controls/gazebo_ros2_control/gazebo_ros2_control/src/gazebo_system.cpp: In member function ‘control_toolbox::Pid gazebo_ros2_control::GazeboSystem::extractPID(std::string, hardware_interface::ComponentInfo)’:
/workspaces/ros2_baustelle_ws/src/ros-controls/gazebo_ros2_control/gazebo_ros2_control/src/gazebo_system.cpp:231:93: warning: ‘antiwindup’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  231 |   return control_toolbox::Pid(kp, ki, kd, max_integral_error, min_integral_error, antiwindup);
      |                                                                                             ^
```