### PR TITLE
Propagate the node clock and logging interface to ResourceManager

### DIFF
--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -65,7 +65,8 @@ public:
     rclcpp::Node::SharedPtr & node,
     gazebo::physics::ModelPtr parent_model,
     sdf::ElementPtr sdf)
-  : hardware_interface::ResourceManager(),
+  : hardware_interface::ResourceManager(
+      node->get_node_clock_interface(), node->get_node_logging_interface()),
     gazebo_system_loader_("gazebo_ros2_control",
       "gazebo_ros2_control::GazeboSystemInterface"),
     logger_(node->get_logger().get_child("GazeboResourceManager"))


### PR DESCRIPTION
Needs: https://github.com/ros-controls/ros2_control/pull/1585

This changes helps to use the clock and logging interface of the node directly. 