### PR TITLE
Add support for getting PID parameters from loaded parameters

### DIFF
--- a/gazebo_ros2_control/include/gazebo_ros2_control/gazebo_system.hpp
+++ b/gazebo_ros2_control/include/gazebo_ros2_control/gazebo_system.hpp
@@ -94,6 +94,9 @@ private:
     const std::string & prefix,
     const hardware_interface::ComponentInfo & joint_info, control_toolbox::Pid & pid);
 
+  bool extractPIDFromParameters(
+    const std::string & control_mode, const std::string & joint_name, control_toolbox::Pid & pid);
+
   /// \brief Private data class
   std::unique_ptr<GazeboSystemPrivate> dataPtr;
 };

--- a/gazebo_ros2_control/include/gazebo_ros2_control/gazebo_system.hpp
+++ b/gazebo_ros2_control/include/gazebo_ros2_control/gazebo_system.hpp
@@ -90,9 +90,9 @@ private:
     const hardware_interface::HardwareInfo & hardware_info,
     gazebo::physics::ModelPtr parent_model);
 
-  control_toolbox::Pid extractPID(
-    std::string prefix,
-    hardware_interface::ComponentInfo joint_info);
+  bool extractPID(
+    const std::string & prefix,
+    const hardware_interface::ComponentInfo & joint_info, control_toolbox::Pid & pid);
 
   /// \brief Private data class
   std::unique_ptr<GazeboSystemPrivate> dataPtr;

--- a/gazebo_ros2_control/src/gazebo_system.cpp
+++ b/gazebo_ros2_control/src/gazebo_system.cpp
@@ -357,8 +357,8 @@ void GazeboSystem::registerJoints(
         if (has_already_registered_pos) {
           RCLCPP_ERROR_STREAM(
             this->nh_->get_logger(),
-            "can't have position and position"
-              << "pid command_interface at same time !!!");
+            "can't have position and position_pid"
+              << "command_interface at same time !!!");
           continue;
         }
         has_already_registered_pos = true;

--- a/gazebo_ros2_control/src/gazebo_system.cpp
+++ b/gazebo_ros2_control/src/gazebo_system.cpp
@@ -203,25 +203,39 @@ bool GazeboSystem::extractPID(
     kd = 0.0;
   }
 
-  if (joint_info.parameters.find(prefix + "max_integral_error") != joint_info.parameters.end()) {
-    max_integral_error = std::stod(joint_info.parameters.at(prefix + "max_integral_error"));
-  } else {
-    max_integral_error = std::numeric_limits<double>::max();
-  }
-
-  if (joint_info.parameters.find(prefix + "min_integral_error") != joint_info.parameters.end()) {
-    min_integral_error = std::stod(joint_info.parameters.at(prefix + "min_integral_error"));
-  } else {
-    min_integral_error = std::numeric_limits<double>::min();
-  }
-
-  if (joint_info.parameters.find(prefix + "antiwindup") != joint_info.parameters.end()) {
-    if (joint_info.parameters.at(prefix + "antiwindup") == "true" ||
-      joint_info.parameters.at(prefix + "antiwindup") == "True")
-    {
-      antiwindup = true;
+  if (are_pids_set) {
+    if (joint_info.parameters.find(prefix + "max_integral_error") != joint_info.parameters.end()) {
+      max_integral_error = std::stod(joint_info.parameters.at(prefix + "max_integral_error"));
+    } else {
+      max_integral_error = std::numeric_limits<double>::max();
     }
+
+    if (joint_info.parameters.find(prefix + "min_integral_error") != joint_info.parameters.end()) {
+      min_integral_error = std::stod(joint_info.parameters.at(prefix + "min_integral_error"));
+    } else {
+      min_integral_error = std::numeric_limits<double>::min();
+    }
+
+    if (joint_info.parameters.find(prefix + "antiwindup") != joint_info.parameters.end()) {
+      if (joint_info.parameters.at(prefix + "antiwindup") == "true" ||
+        joint_info.parameters.at(prefix + "antiwindup") == "True")
+      {
+        antiwindup = true;
+      }
+    }
+
+    RCLCPP_INFO_STREAM(
+      this->nh_->get_logger(),
+      "Setting kp = " << kp << "\t"
+                      << " ki = " << ki << "\t"
+                      << " kd = " << kd << "\t"
+                      << " max_integral_error = " << max_integral_error << "\t"
+                      << "antiwindup =" << std::boolalpha << antiwindup);
+
+    pid.initPid(kp, ki, kd, max_integral_error, min_integral_error, antiwindup);
   }
+  return are_pids_set;
+}
 
   RCLCPP_INFO_STREAM(
     this->nh_->get_logger(),

--- a/gazebo_ros2_control/src/gazebo_system.cpp
+++ b/gazebo_ros2_control/src/gazebo_system.cpp
@@ -157,7 +157,8 @@ bool GazeboSystem::initSim(
       this->nh_->get_logger(), "Using default value: " << this->dataPtr->hold_joints_);
   }
   RCLCPP_DEBUG_STREAM(
-    this->nh_->get_logger(), "hold_joints (system): " << this->dataPtr->hold_joints_ << std::endl);
+    this->nh_->get_logger(),
+    "hold_joints (system): " << std::boolalpha << this->dataPtr->hold_joints_ << std::endl);
 
   registerJoints(hardware_info, parent_model);
   registerSensors(hardware_info, parent_model);

--- a/gazebo_ros2_control/src/gazebo_system.cpp
+++ b/gazebo_ros2_control/src/gazebo_system.cpp
@@ -270,7 +270,7 @@ void GazeboSystem::registerJoints(
 
   for (unsigned int j = 0; j < this->dataPtr->n_dof_; j++) {
     auto & joint_info = hardware_info.joints[j];
-    std::string joint_name = this->dataPtr->joint_names_[j] = joint_info.name;
+    const std::string joint_name = this->dataPtr->joint_names_[j] = joint_info.name;
 
     gazebo::physics::JointPtr simjoint = parent_model->GetJoint(joint_name);
     this->dataPtr->sim_joints_.push_back(simjoint);


### PR DESCRIPTION
Hello!

The issue https://github.com/ros-controls/gazebo_ros2_control/issues/369 will be fixed once this is merged. It seems that for our Humanoids we will be needing this PID feature to make it work using position.

This PR: 

* adds a way to get the PIDs from the loaded parameters as well as the URDF
* If the parameters are found in the URDF, it doesn't check for the parameters in the loaded parameters
* This PR add a way for the PIDs to work also for the `position` interface, because having the `position_pid` interface doesn't help to use many standard ros2 controllers, as many controllers tend to check if they belong to a subset (https://github.com/ros-controls/ros2_controllers/blob/master/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml#L20-L29)
* The proposal to add it from the loaded parameters is due to the fact it it overcomplicates the declaration in the URDF. In our case, we have macros for defining the ros2_control tag information(for example: https://github.com/pal-robotics/talos_robot/blob/5848d42f15340e35d672e323d61079d72b2fb13d/talos_description/urdf/arm/arm.ros2_control.xacro#L22-L30). If we have to define for each joint, we can't make use of the macros.

I hope this helps someone. If this PR changes look fine. I will open the following PR in the gz_ros2_control

```
   <gazebo>
      <plugin filename="libgazebo_ros2_control.so" name="gazebo_ros2_control">
        <ros>
          <argument>--ros-args</argument>
          <argument>--params-file</argument>
          <argument>$(find talos_description)/config/gazebo_controller_manager_cfg.yaml</argument>
        </ros>
        <hold_joints>false</hold_joints>
        <parameters>$(find talos_description)/config/gazebo_controller_manager_cfg.yaml</parameters>
      </plugin>
    </gazebo>
```

Defining it like this should work

```
gazebo_ros2_control:
  ros__parameters:
    pid_gains:
      position:
        leg_left_1_joint: {kp:  5000.0, kd: 20.0, ki:  5.0, max_integral_error: 10000.0}
        leg_left_2_joint: {kp:  5000.0, kd: 20.0, ki:  5.0, max_integral_error: 10000.0}
        leg_left_3_joint: {kp:  5000.0, kd: 20.0, ki:  5.0, max_integral_error: 10000.0}
        leg_left_4_joint: {kp:  5000.0, kd: 20.0, ki:  5.0, max_integral_error: 10000.0}
        leg_left_5_joint: {kp:  5000, kd: 20.0, ki:  5.0, max_integral_error: 10000.0}
        leg_left_6_joint: {kp:  5000.0, kd: 20.0, ki:  5.0, max_integral_error: 10000.0}