### PR TITLE
Don't spin the executor if the sim is paused

### DIFF
--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -397,6 +397,8 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
       while (rclcpp::ok() && !impl_->stop_) {
         if (impl_->parent_model_->GetWorld()->IsPaused() == false) {
           impl_->executor_->spin_once();
+        } else {
+          std::this_thread::sleep_for(std::chrono::microseconds(100));
         }
       }
     };

--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -395,7 +395,9 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
   auto spin = [this]()
     {
       while (rclcpp::ok() && !impl_->stop_) {
-        impl_->executor_->spin_once();
+        if (impl_->parent_model_->GetWorld()->IsPaused() == false) {
+          impl_->executor_->spin_once();
+        }
       }
     };
   impl_->thread_executor_spin_ = std::thread(spin);


### PR DESCRIPTION
After the refactoring done by https://github.com/ros-controls/ros2_control/pull/1638, the `switch_controller` service has a working timeout for each controller. This time is hardcoded within the spawner.py to 5s.

If the simulation is started paused, like with

```python
    gazebo = IncludeLaunchDescription(
                PythonLaunchDescriptionSource([os.path.join(
                    get_package_share_directory('gazebo_ros'), 'launch'), '/gazebo.launch.py']),
                launch_arguments={
                    'pause': 'true'}.items()
             )
```

then the CM services are started but the update method is not called yet. This leads to running into the timeout
```
[gzserver-5] [ERROR] [1727713930.188912404] [controller_manager]: Switch controller timed out after 5.000000 seconds!
[spawner-18] [ERROR] [1727713930.190697406] [spawner_joint_state_broadcaster]: Failed to activate controller
```
The same happens if a running simulation is paused and a service call to the CM is done.

As there is currently no possibility to pause the services in the CM, I see the possibility to just not spin the executor. Otherwise we have to change the API of the CM.